### PR TITLE
Pass high level procedure vars along the launch msg

### DIFF
--- a/lib/flack/app/message.rb
+++ b/lib/flack/app/message.rb
@@ -49,7 +49,7 @@ class Flack::App
 
     dom = msg['domain'] || 'domain0'
     src = msg['tree'] || msg['name']
-    vars = msg.delete('vars') || {}
+    vars = msg['vars'] || {}
 
     return respond_bad_request(env, 'missing "tree" or "name" in launch msg') \
       unless src

--- a/lib/flack/app/message.rb
+++ b/lib/flack/app/message.rb
@@ -49,12 +49,14 @@ class Flack::App
 
     dom = msg['domain'] || 'domain0'
     src = msg['tree'] || msg['name']
+    vars = msg.delete('vars') || {}
 
     return respond_bad_request(env, 'missing "tree" or "name" in launch msg') \
       unless src
 
     opts = {}
     opts[:domain] = dom
+    opts[:vars] = vars
 
     r = @unit.launch(src, opts)
 


### PR DESCRIPTION
Pass "high level" vars to Flor by POSTing to Flack's /messages : `{ point: 'launch', tree: t, vars: vars }`. 

Aligns with `Flor:Scheduler:launch(source_or_path, opts={})`, where opts can receive `vars:`