### PR TITLE
Accept `fields` when POSTing to `/messages`

### DIFF
--- a/lib/flack/app/message.rb
+++ b/lib/flack/app/message.rb
@@ -50,6 +50,7 @@ class Flack::App
     dom = msg['domain'] || 'domain0'
     src = msg['tree'] || msg['name']
     vars = msg['vars'] || {}
+    fields = msg['fields'] || {}
 
     return respond_bad_request(env, 'missing "tree" or "name" in launch msg') \
       unless src
@@ -57,6 +58,7 @@ class Flack::App
     opts = {}
     opts[:domain] = dom
     opts[:vars] = vars
+    opts[:fields] = fields
 
     r = @unit.launch(src, opts)
 

--- a/spec/app/message_spec.rb
+++ b/spec/app/message_spec.rb
@@ -147,7 +147,7 @@ describe '/message' do
         expect(es.collect(&:status)).to eq(%w[ active ])
       end
 
-      it 'launches and execution vars defaults to an emtpy hash' do
+      it 'launches and vars and payload fields defaults to empty hash' do
 
         t = Flor::Lang.parse("stall _", "#{__FILE__}:#{__LINE__}")
 
@@ -179,14 +179,16 @@ describe '/message' do
         es = @app.unit.executions.all
 
         expect(es.collect(&:data)[0]['nodes']['0']['vars']).to eq({})
+        expect(es.collect(&:data)[0]['nodes']['0']['payload']).to eq({})
       end
 
-      it 'launches and accept execution vars' do
+      it 'launches and accept vars and payload fields' do
 
         t = Flor::Lang.parse("stall _", "#{__FILE__}:#{__LINE__}")
 
-        vars = {'a' => 'AA'}
-        msg = { point: 'launch', domain: 'org.example', tree: t, vars: vars}
+        vars = {'var' => 'a_var'}
+        fields = {'field' => 'a_field'}
+        msg = { point: 'launch', domain: 'org.example', tree: t, vars: vars, fields: fields}
 
         r = @app.call(make_env(method: 'POST', path: '/message', body: msg))
 
@@ -214,6 +216,7 @@ describe '/message' do
         es = @app.unit.executions.all
 
         expect(es.collect(&:data)[0]['nodes']['0']['vars']).to eq(vars)
+        expect(es.collect(&:data)[0]['nodes']['0']['payload']).to eq(fields)
       end
 
     end


### PR DESCRIPTION
Hi
I implemented the support  for `fields`, the same way I did for `vars`. I should have been more thorough the first time and deal with both in a single PR, sorry about that.

I reused the same tests, since it's really just a lookup in a hash, and I didn't want to add ~70 lines of code just for that.

Please let me know if that suits you.

Thanks