### PR TITLE
Minor refinements to make start|stop|restart actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ stop:
 	@if [ -f $(PID_FILE) ]; then \
       echo "stopping flack pid `cat $(PID_FILE)`"; \
       kill `cat $(PID_FILE)`; \
-      rm $(PID_FILE); \
     fi
 
 restart:

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ c: curl
 start:
 	@if [ ! -f $(PID_FILE) ]; then \
       bundle exec rackup -p $(PORT) -P $(PID_FILE) -D; \
+      sleep 1; \
       echo "listening on $(PORT), pid `cat $(PID_FILE)`"; \
     else \
       echo "already running at `cat $(PID_FILE)`"; \
@@ -67,5 +68,5 @@ stop:
     fi
 
 restart:
-	if [ -f $(PID_FILE) ]; then make stop; fi; make start
+	@if [ -f $(PID_FILE) ]; then make -s stop; fi; make -s start
 


### PR DESCRIPTION
Hi,

These are the last small refinements we discussed touching those actions.

Added a `sleep 1` in `start` so we're not trying to read an empty file and made `restart` silent. We also didn't need to remove the pid file manually, so I got rid of that too.

Thank you,