### PR TITLE
Import httpclient as runtime_dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ PATH
   specs:
     flack (0.10.0)
       flor (~> 0.10)
+      httpclient (~> 2.8)
       rack (~> 1.6)
       sequel (~> 4)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,7 @@ GEM
     fugit (1.0.0)
       et-orbi (>= 1.0.5)
       raabro (~> 1.1)
+    httpclient (2.8.3)
     jdbc-sqlite3 (3.8.11.2)
     munemo (1.0.1)
     raabro (1.1.3)

--- a/flack.gemspec
+++ b/flack.gemspec
@@ -33,6 +33,7 @@ A web front-end to the flor workflow engine
 
   s.add_runtime_dependency 'rack', '~> 1.6'
   s.add_runtime_dependency 'sequel', '~> 4'
+  s.add_runtime_dependency 'httpclient', '~> 2.8'
 
   s.add_development_dependency 'rspec', '~> 3'
 


### PR DESCRIPTION
As discussed a little while ago; just importing `httpclient` as a runtime dependency.
Required mainly by:
- HTTP hooks e.g. (floraison/pollen)
- "RESTful Taskers", who need to speak to remote services over HTTP