### PR TITLE
Introduce the 'reply' POST message

### DIFF
--- a/envs/test/lib/taskers/remote/dot.json
+++ b/envs/test/lib/taskers/remote/dot.json
@@ -1,0 +1,4 @@
+# remote tasker
+
+require: 'tasker.rb'
+class: RemoteTasker

--- a/envs/test/lib/taskers/remote/tasker.rb
+++ b/envs/test/lib/taskers/remote/tasker.rb
@@ -1,0 +1,10 @@
+# tasker.rb
+
+class RemoteTasker < Flor::BasicTasker
+
+  def task
+
+    # noop
+  end
+end
+


### PR DESCRIPTION
Adds support for the 'reply' message. Relates to #5 

Use case: in our implementation, a `WebTasker` sends an HTTP message to a remote system, and awaits for a response. 
That system will eventually reply back with a properly built message, containing the `WebTasker`'s `payload`.

Since reply is an alias for return, I chose `reply`. IMO, it feels clearer from the standpoint of a remote service to "reply" back to Flor.

Please let me know if this suits you or if there's anything to adjust.